### PR TITLE
fix(rss): non-seo title and description fallback

### DIFF
--- a/plugins/generateRss.js
+++ b/plugins/generateRss.js
@@ -27,11 +27,13 @@ const createFeed = async (feed, HOST) => {
     }
 
     posts.forEach((post) => {
+      const title = post.data.seoTitle ?? post.data.title[0]?.text
+      const description = post.data.seoDescription ?? post.data.description[0]?.text
       feed.addItem({
-        title: post.data.seoTitle,
+        title: title,
         id: post.id,
         link: `${HOST}/post/${post.uid}`,
-        description: post.data.seoDescription,
+        description: description,
         category: post.tags.join(', '),
         published: new Date(post.last_publication_date),
         image: {
@@ -43,7 +45,7 @@ const createFeed = async (feed, HOST) => {
         },
         date: new Date(post.last_publication_date),
         content:
-          post.data.seoDescription + ` <a href="${HOST}/post/${post.uid}">${HOST}/post/${post.uid}</a>`
+          description + ` <a href="${HOST}/post/${post.uid}">${HOST}/post/${post.uid}</a>`
       })
     })
   } catch (error) {


### PR DESCRIPTION
While being subscribed to the RSS feed I noticed, that some posts are missing a title and description.

I've found out, that the index and post detail views use the `post.data.title`, while the feed uses the `post.data.seoTitle`. I do not know the reason behind the difference and if it would be ok to align them. Therefore, I've only added a fallback to the actual title/description property (or at least I hope so), but somehow the data structure seems to be different to the one on the page views?

Sorry, I've never worked with Prismic or NuxtJS and I don't even know JavaScript that well. Hopefully this will not break anything.

But, I got it to work on my local machine.

Before:
![image](https://github.com/system76/blog/assets/31095474/5737526d-cfc4-46ef-a02a-57a165d12f8f)

After:
![image](https://github.com/system76/blog/assets/31095474/52555b7e-ea64-4bc4-aae0-df151f435993)


